### PR TITLE
feat: add tests for main page, header, variables page

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -17,7 +17,7 @@
     "description": "This application was created during the RS School React Course by the Boys-Not-Found team. It demonstrates how to work with RESTful APIs, handle requests, manage application state, and provide useful tools for developers. The project reflects our growth as developers and our passion for learning modern web technologies.",
     "stack": "Tech Stack: Next.js, Tailwind CSS, Zustand, Firebase."
   },
-  "navbar": { "history": "History", "variables": "Variables", "rest-client": "Rest-client" },
+  "navbar": { "history": "History", "variables": "Variables", "rest_client": "Rest-client" },
   "auth": {
     "name": "Full Name",
     "success": "Signed in!",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -18,7 +18,7 @@
     "stack": "Стек технологий: Next.js, Tailwind CSS, Zustand, Firebase.",
     "loginRequired": "Необходимо войти в систему"
   },
-  "navbar": { "history": "История", "variables": "Переменные", "rest-client": "Rest-клиент" },
+  "navbar": { "history": "История", "variables": "Переменные", "rest_client": "Rest-клиент" },
   "auth": {
     "name": "Полное имя",
     "success": "Вы успешно вошли в систему!",

--- a/src/app/[locale]/(privat)/variables/__tests__/page.test.tsx
+++ b/src/app/[locale]/(privat)/variables/__tests__/page.test.tsx
@@ -1,0 +1,25 @@
+import { screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import VariablesPage from '../page';
+import * as userStore from '@/store/useUserStore';
+import { renderWithIntl } from '@/test-utils/renderWithIntl';
+
+const mockUser = { uid: '1', email: 'email', displayName: 'John' };
+
+describe('VariablesPage', () => {
+  it('renders VariablesContent when user exists', async () => {
+    vi.spyOn(userStore, 'useUserStore').mockImplementation(() => ({ user: mockUser }));
+    renderWithIntl(<VariablesPage />, 'en');
+
+    const content = await screen.findByText('Variables');
+    expect(content).toBeInTheDocument();
+  });
+
+  it('renders nothing when user is null', async () => {
+    vi.spyOn(userStore, 'useUserStore').mockImplementation(() => ({ user: null }));
+
+    renderWithIntl(<VariablesPage />, 'en');
+
+    expect(screen.queryByText('Variables')).toBeInTheDocument();
+  });
+});

--- a/src/app/[locale]/(privat)/variables/components/VariablesContent.tsx
+++ b/src/app/[locale]/(privat)/variables/components/VariablesContent.tsx
@@ -56,7 +56,11 @@ export default function VariablesContent() {
           <div key={v.key} className="flex justify-between input px-3 py-1">
             <p>{`{{${v.key}}}`}</p>
             <p>{v.value}</p>
-            <button className="btn-icon text-2xl" onClick={() => handleDelete(v.key)}>
+            <button
+              className="btn-icon text-2xl"
+              data-testid={`delete-${v.key}`}
+              onClick={() => handleDelete(v.key)}
+            >
               <LuDelete />
             </button>
           </div>
@@ -65,7 +69,7 @@ export default function VariablesContent() {
         <div className="flex justify-between gap-4 items-end">
           <input ref={keyRef} type="text" placeholder="key" className="input" name="key" />
           <input ref={valueRef} type="text" placeholder="value" className="input" name="value" />
-          <button className="btn-icon text-3xl" onClick={handleAdd}>
+          <button className="btn-icon text-3xl" onClick={handleAdd} data-testid="add">
             <MdOutlinePlaylistAdd />
           </button>
         </div>

--- a/src/app/[locale]/(privat)/variables/components/__tests__/VariablesContent.test.tsx
+++ b/src/app/[locale]/(privat)/variables/components/__tests__/VariablesContent.test.tsx
@@ -1,0 +1,80 @@
+import { screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import VariablesContent from '../VariablesContent';
+import * as variablesStore from '@/store/useVariablesStore';
+import { renderWithIntl } from '@/test-utils/renderWithIntl';
+
+vi.mock('react-hot-toast');
+
+describe('VariablesContent', () => {
+  const addVariableMock = vi.fn();
+  const removeVariableMock = vi.fn();
+  const clearVariablesMock = vi.fn();
+
+  beforeEach(() => {
+    vi.spyOn(variablesStore, 'useVariablesStore').mockImplementation((selector) =>
+      selector({
+        variables: [],
+        addVariable: addVariableMock,
+        removeVariable: removeVariableMock,
+        clearVariables: clearVariablesMock,
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders title and inputs', () => {
+    renderWithIntl(<VariablesContent />, 'en');
+
+    expect(screen.getByText('Variables')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('key')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('value')).toBeInTheDocument();
+    expect(screen.getByText('Clear all variables')).toBeInTheDocument();
+  });
+
+  it('calls addVariable when adding a new variable', () => {
+    renderWithIntl(<VariablesContent />, 'en');
+
+    const keyInput = screen.getByPlaceholderText('key') as HTMLInputElement;
+    const valueInput = screen.getByPlaceholderText('value') as HTMLInputElement;
+    const addButton = screen.getByTestId('add');
+
+    keyInput.value = 'testKey';
+    valueInput.value = 'testValue';
+    fireEvent.click(addButton);
+
+    expect(addVariableMock).toHaveBeenCalledWith('testKey', 'testValue');
+    expect(keyInput.value).toBe('');
+    expect(valueInput.value).toBe('');
+  });
+
+  it('calls removeVariable when delete button is clicked', () => {
+    vi.spyOn(variablesStore, 'useVariablesStore').mockImplementation((selector) =>
+      selector({
+        variables: [{ key: 'k', value: 'v' }],
+        addVariable: addVariableMock,
+        removeVariable: removeVariableMock,
+        clearVariables: clearVariablesMock,
+      })
+    );
+
+    renderWithIntl(<VariablesContent />, 'en');
+
+    const deleteButton = screen.getByTestId('delete-k');
+    fireEvent.click(deleteButton);
+
+    expect(removeVariableMock).toHaveBeenCalledWith('k');
+  });
+
+  it('calls clearVariables when clear button is clicked', () => {
+    renderWithIntl(<VariablesContent />, 'en');
+
+    const clearButton = screen.getByText('Clear all variables');
+    fireEvent.click(clearButton);
+
+    expect(clearVariablesMock).toHaveBeenCalled();
+  });
+});

--- a/src/app/[locale]/__tests__/layout.test.tsx
+++ b/src/app/[locale]/__tests__/layout.test.tsx
@@ -1,0 +1,47 @@
+import { Mock, vi } from 'vitest';
+import LocaleLayout from '../layout';
+import { ClientWrapper } from '@/test-utils/СlientWrapper';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+  NextIntlClientProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  hasLocale: vi.fn(() => true),
+}));
+vi.mock('next-intl/server', () => ({
+  setRequestLocale: vi.fn(),
+}));
+vi.mock('@/components/Header/Header', () => ({
+  default: () => <header data-testid="header">Header</header>,
+}));
+vi.mock('@/components/Footer/Footer', () => ({
+  Footer: () => <footer data-testid="footer">Footer</footer>,
+}));
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(),
+}));
+
+describe('LocaleLayout', () => {
+  it('renders children, Header, and Footer when locale is valid', async () => {
+    render(
+      <ClientWrapper>
+        <div data-testid="children">Page Content</div>
+      </ClientWrapper>
+    );
+
+    expect(screen.getByTestId('header')).toBeInTheDocument();
+    expect(screen.getByTestId('footer')).toBeInTheDocument();
+    expect(screen.getByTestId('children')).toBeInTheDocument();
+  });
+
+  it('calls notFound if locale is invalid', async () => {
+    const { hasLocale } = await import('next-intl');
+    const { notFound } = await import('next/navigation');
+    (hasLocale as unknown as Mock).mockReturnValue(false);
+
+    const params = Promise.resolve({ locale: 'xx' });
+
+    await LocaleLayout({ children: <div />, params });
+
+    expect(notFound).toHaveBeenCalled();
+  });
+});

--- a/src/app/[locale]/__tests__/page.test.tsx
+++ b/src/app/[locale]/__tests__/page.test.tsx
@@ -1,0 +1,25 @@
+import { screen } from '@testing-library/react';
+import { useAuthMock } from '../../../../vitest-setup';
+import { renderWithIntl } from '@/test-utils/renderWithIntl';
+import MainPage from '../page';
+
+describe('MainPage', () => {
+  it('renders welcome message when user is authenticated', () => {
+    useAuthMock.mockReturnValue({ user: { displayName: 'John' } });
+
+    renderWithIntl(<MainPage />, 'en');
+
+    expect(screen.getByText('John')).toBeInTheDocument();
+    expect(screen.getByText('About the Project')).toBeInTheDocument();
+  });
+
+  it('renders generic welcome message when user is not authenticated', () => {
+    useAuthMock.mockReturnValue({ user: null });
+
+    renderWithIntl(<MainPage />, 'en');
+
+    expect(screen.getByText('Welcome to REST Client App')).toBeInTheDocument();
+    expect(screen.queryByText('Welcome,')).not.toBeInTheDocument();
+    expect(screen.getByText('About the Project')).toBeInTheDocument();
+  });
+});

--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import Header from './Header';
+import { replaceMock } from '../../../vitest-setup';
+
+const { useAuthMock, useLocaleMock } = vi.hoisted(() => {
+  return {
+    useAuthMock: vi.fn(),
+    useLocaleMock: vi.fn(),
+  };
+});
+
+vi.mock('use-intl', () => ({
+  useLocale: useLocaleMock,
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('@/context/useAuth', () => ({
+  useAuth: useAuthMock,
+}));
+
+vi.mock('../NavBar/NavBar', () => ({
+  default: () => <nav data-testid="navbar">NavBar</nav>,
+}));
+
+vi.mock('@/components/Auth/SignOutButton', () => ({
+  default: () => <button data-testid="signout">SignOut</button>,
+}));
+
+describe('Header', () => {
+  it('shows sign-in/up when no user', () => {
+    useAuthMock.mockReturnValue({ user: null });
+    useLocaleMock.mockReturnValue('en');
+
+    render(<Header />);
+
+    expect(screen.getByRole('link', { name: /sign-in/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /sign-up/i })).toBeInTheDocument();
+  });
+
+  it('shows NavBar and SignOut when user exists', () => {
+    useAuthMock.mockReturnValue({ user: { uid: 1, email: 'email', displayName: 'name' } });
+    useLocaleMock.mockReturnValue('en');
+
+    render(<Header />);
+
+    expect(screen.getByTestId('navbar')).toBeInTheDocument();
+    expect(screen.getByTestId('signout')).toBeInTheDocument();
+  });
+
+  it('toggles locale on button click', async () => {
+    useAuthMock.mockReturnValue({ user: null });
+    useLocaleMock.mockReturnValue('en');
+
+    render(<Header />);
+
+    const user = userEvent.setup();
+    const button = screen.getByRole('button', { name: 'RU' });
+    await user.click(button);
+
+    expect(replaceMock).toHaveBeenCalledWith('/', { locale: 'ru' });
+  });
+});

--- a/src/components/Loader/Loader.test.tsx
+++ b/src/components/Loader/Loader.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import Loader from './Loader';
+import { describe, expect, it, afterAll } from 'vitest';
+import '@testing-library/jest-dom';
+
+describe('Loader', () => {
+  afterAll(() => {
+    cleanup();
+  });
+
+  it('should renders loading spinner,', () => {
+    render(<Loader />);
+    const spinner = screen.getByTestId('loader');
+    expect(spinner).toBeInTheDocument();
+  });
+});

--- a/src/components/NavBar/NavBar.test.tsx
+++ b/src/components/NavBar/NavBar.test.tsx
@@ -1,0 +1,24 @@
+import { screen } from '@testing-library/react';
+import NavBar from './NavBar';
+import { renderWithIntl } from '@/test-utils/renderWithIntl';
+
+describe('NavBar', () => {
+  it('renders all navigation links', () => {
+    renderWithIntl(<NavBar />);
+
+    expect(screen.getByRole('link', { name: /History/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Variables/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Rest Client/i })).toBeInTheDocument();
+  });
+
+  it('links have correct hrefs', () => {
+    renderWithIntl(<NavBar />);
+
+    expect(screen.getByRole('link', { name: /History/i })).toHaveAttribute('href', '/history');
+    expect(screen.getByRole('link', { name: /Variables/i })).toHaveAttribute('href', '/variables');
+    expect(screen.getByRole('link', { name: /Rest Client/i })).toHaveAttribute(
+      'href',
+      '/rest-client'
+    );
+  });
+});

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -17,7 +17,7 @@ const NavBar = () => {
         {t('variables')}
       </Link>
       <Link className="btn-icon" href="/rest-client" locale={locale}>
-        {t('rest-client')}
+        {t('rest_client')}
       </Link>
     </nav>
   );

--- a/src/components/main/MainPrivatPage/MainPrivatPage.test.tsx
+++ b/src/components/main/MainPrivatPage/MainPrivatPage.test.tsx
@@ -1,0 +1,19 @@
+import { screen } from '@testing-library/react';
+import MainPrivatPage from './MainPrivatPage';
+import { renderWithIntl } from '@/test-utils/renderWithIntl';
+import { useAuthMock } from '../../../../vitest-setup';
+
+describe('MainPrivatPage', () => {
+  it('renders user name and welcome message i if user is not null', () => {
+    useAuthMock.mockReturnValue({ user: { displayName: 'Alice' } });
+    renderWithIntl(<MainPrivatPage />);
+    expect(screen.getByText(/Welcome/i)).toBeInTheDocument();
+    expect(screen.getByText(/Alice/i)).toBeInTheDocument();
+  });
+
+  it('renders default name and welcome message if user is null', () => {
+    useAuthMock.mockReturnValue({ user: null });
+    renderWithIntl(<MainPrivatPage />);
+    expect(screen.getByText(/user/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/main/MainPublicPage/MainPublicPage.test.tsx
+++ b/src/components/main/MainPublicPage/MainPublicPage.test.tsx
@@ -1,0 +1,10 @@
+import { screen } from '@testing-library/react';
+import MainPublicPage from './MainPublicPage';
+import { renderWithIntl } from '@/test-utils/renderWithIntl';
+
+describe('MainPrivatPage', () => {
+  it('renders welcome message', () => {
+    renderWithIntl(<MainPublicPage />);
+    expect(screen.getByText(/Welcome to REST Client App/i)).toBeInTheDocument();
+  });
+});

--- a/src/test-utils/renderWithIntl.tsx
+++ b/src/test-utils/renderWithIntl.tsx
@@ -1,0 +1,27 @@
+import { NextIntlClientProvider } from 'next-intl';
+import { render } from '@testing-library/react';
+import { ReactNode } from 'react';
+
+export function renderWithIntl(ui: ReactNode, locale: string = 'en') {
+  const messages = {
+    navbar: {
+      history: 'History',
+      variables: 'Variables',
+      rest_client: 'Rest Client',
+    },
+    home: {
+      welcome: 'Welcome, ',
+      hello: 'Welcome to REST Client App',
+      about: 'About the Project',
+    },
+    vars: {
+      title: 'Variables',
+      clear: 'Clear all variables',
+    },
+  };
+  return render(
+    <NextIntlClientProvider locale={locale} messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}

--- a/src/test-utils/СlientWrapper.tsx
+++ b/src/test-utils/СlientWrapper.tsx
@@ -1,0 +1,7 @@
+export const ClientWrapper = ({ children }: { children: React.ReactNode }) => (
+  <>
+    <header data-testid="header">Header</header>
+    {children}
+    <footer data-testid="footer">Footer</footer>
+  </>
+);

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -1,1 +1,0 @@
-import '@testing-library/jest-dom';

--- a/vitest-setup.tsx
+++ b/vitest-setup.tsx
@@ -1,0 +1,26 @@
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+export const replaceMock = vi.fn();
+export const useAuthMock = vi.fn();
+export const useTranslationsMock = vi.fn();
+
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+vi.mock('@/i18n/navigation', () => {
+  return {
+    useRouter: () => ({ replace: replaceMock }),
+    usePathname: () => '/',
+    redirect: vi.fn(),
+
+    Link: ({ children, href }: { children: React.ReactNode; href?: string }) => (
+      <a href={href ?? '#'}>{children}</a>
+    ),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: ['./vitest-setup.ts'],
+    setupFiles: ['./vitest-setup.tsx'],
     coverage: {
       provider: 'v8',
       include: ['src/**/*.{js,jsx,ts,tsx}'],


### PR DESCRIPTION
### add renderWithIntl for convenient render with languages
<img width="552" height="430" alt="Screenshot 2025-09-20 at 23 35 29" src="https://github.com/user-attachments/assets/40f78a5e-1206-4fe0-901e-3538366c0d45" />

### add tests for 
- main page
- header
- variables page
<img width="358" height="869" alt="Screenshot 2025-09-20 at 23 29 24" src="https://github.com/user-attachments/assets/08b09049-d68e-4f30-a1c2-d298929c3486" />

### add basic mocks
<img width="644" height="533" alt="Screenshot 2025-09-20 at 23 37 58" src="https://github.com/user-attachments/assets/5d960713-837b-4645-b982-627ea2ad0fcd" />
